### PR TITLE
Add feature:  demonstration data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 ## ignore the published_binaries/ directory
 published_binaries/
 release_zipfiles/
-
 TrackerApp_CS690/
 *.zip
 

--- a/TrackerAppProject/TrackerApp/DataStore.cs
+++ b/TrackerAppProject/TrackerApp/DataStore.cs
@@ -88,7 +88,7 @@ public class DataStore : IDataStore
         return _moodRecords.Any(record => record.Trigger != null && record.Trigger.StartsWith("(demo)", StringComparison.OrdinalIgnoreCase));
     }
 
-    private void LoadDemoData()
+    public void AddTheDemoData()
     {
         var demoRecords = DemoMoodGenerator.GenerateMoodUpdates();
 
@@ -97,7 +97,8 @@ public class DataStore : IDataStore
         {
             AddMoodRecord(record);
         }
-
+        // Save it
+        SaveData();
     }
 
     public bool DeleteDemoData()

--- a/TrackerAppProject/TrackerApp/DataStore.cs
+++ b/TrackerAppProject/TrackerApp/DataStore.cs
@@ -24,6 +24,7 @@ public class DataStore : IDataStore
     private static DataStore? _instance;
     private static readonly object Lock = new();
     private readonly string _databaseFilePath;
+    private readonly string _demoDatabaseFilePath;
     private List<MoodRecord> _moodRecords = [];
     private UserAccount _userCredentials = new();
 
@@ -80,6 +81,28 @@ public class DataStore : IDataStore
         // If we get to this point, default values
         _moodRecords = [];
         _userCredentials = new UserAccount();
+    }
+    
+    public bool HasDemoTrigger()
+    {
+        return _moodRecords.Any(record => record.Trigger != null && record.Trigger.StartsWith("(demo)", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void LoadDemoData()
+    {
+        var demoRecords = DemoMoodGenerator.GenerateMoodUpdates();
+
+        if (HasDemoTrigger()) return;
+        foreach (var record in demoRecords)
+        {
+            AddMoodRecord(record);
+        }
+
+    }
+
+    public bool DeleteDemoData()
+    {
+         return _moodRecords.RemoveAll(record => record.Trigger != null && record.Trigger.StartsWith("(demo) ", StringComparison.OrdinalIgnoreCase)) > 0;
     }
 
     public bool IsFirstLaunch()

--- a/TrackerAppProject/TrackerApp/DemoMoodGenerator.cs
+++ b/TrackerAppProject/TrackerApp/DemoMoodGenerator.cs
@@ -1,0 +1,60 @@
+namespace TrackerApp;
+
+public class DemoMoodGenerator
+{
+    private static readonly Random random = new Random();
+    private static readonly string[] triggers = new string[]
+    {
+        "Just got an A on my assignment",
+        "Had a great conversation with a friend",
+        "Struggling with a difficult homework problem",
+        "Looking forward to relaxing",
+        "Feeling overwhelmed with schoolwork",
+        "Just got pizza!",
+        "Had a frustrating conversation with a professor",
+        "Excited for my afternoon class",
+        "Feeling anxious about an upcoming exam",
+        "Just finished a long project",
+        "Nice bike ride!",
+        "Feeling stressed about deadlines",
+        "Just got a good grade on a quiz",
+        "Had a nice walk outside",
+        "Feeling tired and need a nap"
+    };
+
+    public static List<MoodRecord> GenerateMoodUpdates(int numberOfDays=45)
+    {
+        // Aim is to do the following:
+        // - Generate N days of 'demo' updates going back from current local time when invoked
+        // - Add (demo) into the trigger info for removal?  Or just an admin option to 'clear all data'?
+        
+        var moods = TrackerUtils.MoodColors.Keys.ToList();
+        var moodRecords = new List<MoodRecord>();
+
+        var currentDate = DateTime.Now;
+        for (int i = 0; i < numberOfDays; i++)
+        {
+            var date = currentDate.AddDays(-i);
+            var updatesForDay = random.Next(2, 7); // Random number of updates between 2 and 6 per day
+
+            for (int j = 0; j < updatesForDay; j++)
+            {
+                var mood = moods[random.Next(moods.Count)];
+                var trigger = "(demo) "; // make deleting demo data easier
+                trigger = trigger + ( random.NextDouble() < 0.5 ? triggers[random.Next(triggers.Length)] : null );
+                var hour = random.Next(7, 24); // Confine updates to likely waking hours
+                var minute = random.Next(60);
+                var timestamp = new DateTime(date.Year, date.Month, date.Day, hour, minute, 0);
+
+                moodRecords.Add(new MoodRecord
+                {
+                    Mood = mood,
+                    Trigger = trigger,
+                    Timestamp = timestamp
+                });
+            }
+        }
+
+        return moodRecords;
+    }
+}

--- a/TrackerAppProject/TrackerApp/Tracker.cs
+++ b/TrackerAppProject/TrackerApp/Tracker.cs
@@ -115,6 +115,16 @@ internal class Tracker
                 if (confirmation) _dataStore.RemoveLastMoodRecord();
                 TrackerUtils.EnterToContinue();
                 break;
+            case "Remove All Updates":
+                return;
+            case "Add Demonstration Data":
+                _dataStore.AddTheDemoData();
+                TrackerUtils.CenteredMessageEnterContinue("Added Demonstration Data");
+                return;
+            case "Remove Demonstration Data":
+                _dataStore.DeleteDemoData();
+                TrackerUtils.CenteredMessageEnterContinue("Removed Demonstration data");
+                return;
             case "Return to Main Menu":
                 AnsiConsole.Clear();
                 return;

--- a/TrackerAppProject/TrackerApp/TrackerUtils.cs
+++ b/TrackerAppProject/TrackerApp/TrackerUtils.cs
@@ -53,6 +53,12 @@ public static class TrackerUtils
         if (clearscreen) AnsiConsole.Clear();
     }
 
+    public static void CenteredMessageEnterContinue(string message, string color = "green")
+    {
+        var rule = new Rule($"{message} -- please select Enter to continue" ).Centered().RuleStyle(color);
+        AnsiConsole.Write(rule);
+    }
+    
     public static void WelcomeScreen(string[] args)
     {
         AnsiConsole.Clear();

--- a/TrackerAppProject/TrackerApp/TrackerUtils.cs
+++ b/TrackerAppProject/TrackerApp/TrackerUtils.cs
@@ -53,10 +53,12 @@ public static class TrackerUtils
         if (clearscreen) AnsiConsole.Clear();
     }
 
-    public static void CenteredMessageEnterContinue(string message, string color = "green")
+    public static void CenteredMessageEnterContinue(string message, string color = "green", bool clearscreen=true)
     {
         var rule = new Rule($"{message} -- please select Enter to continue" ).Centered().RuleStyle(color);
         AnsiConsole.Write(rule);
+        AnsiConsole.Prompt(new TextPrompt<string>("").AllowEmpty());
+        if (clearscreen) AnsiConsole.Clear();
     }
     
     public static void WelcomeScreen(string[] args)

--- a/TrackerAppProject/TrackerApp/UserInputHandler.cs
+++ b/TrackerAppProject/TrackerApp/UserInputHandler.cs
@@ -60,6 +60,9 @@ public class UserInputHandler(IAnsiConsole console)
         var AdminMenuChoices = new List<string>();
 
         if (DataStore.Instance.ContainsRecords()) AdminMenuChoices.Add("Remove Last Update");
+        if (DataStore.Instance.ContainsRecords()) AdminMenuChoices.Add("Remove All Updates");
+        if (!DataStore.Instance.HasDemoTrigger()) AdminMenuChoices.Add("Add Demo Records");
+        if (DataStore.Instance.HasDemoTrigger()) AdminMenuChoices.Add("Remove Demo Records");
         
         AdminMenuChoices.Add("Exit to Main Menu");
 

--- a/TrackerAppProject/TrackerApp/UserInputHandler.cs
+++ b/TrackerAppProject/TrackerApp/UserInputHandler.cs
@@ -61,8 +61,8 @@ public class UserInputHandler(IAnsiConsole console)
 
         if (DataStore.Instance.ContainsRecords()) AdminMenuChoices.Add("Remove Last Update");
         if (DataStore.Instance.ContainsRecords()) AdminMenuChoices.Add("Remove All Updates");
-        if (!DataStore.Instance.HasDemoTrigger()) AdminMenuChoices.Add("Add Demo Records");
-        if (DataStore.Instance.HasDemoTrigger()) AdminMenuChoices.Add("Remove Demo Records");
+        if (!DataStore.Instance.HasDemoTrigger()) AdminMenuChoices.Add("Add Demonstration Data");
+        if (DataStore.Instance.HasDemoTrigger()) AdminMenuChoices.Add("Remove Demonstration Data");
         
         AdminMenuChoices.Add("Exit to Main Menu");
 

--- a/TrackerAppProject/TrackerApp/UserInputHandler.cs
+++ b/TrackerAppProject/TrackerApp/UserInputHandler.cs
@@ -60,7 +60,7 @@ public class UserInputHandler(IAnsiConsole console)
         var AdminMenuChoices = new List<string>();
 
         if (DataStore.Instance.ContainsRecords()) AdminMenuChoices.Add("Remove Last Update");
-
+        
         AdminMenuChoices.Add("Exit to Main Menu");
 
         return Markup.Remove(_console.Prompt(new SelectionPrompt<string>()


### PR DESCRIPTION
Add feature to generate 45 days of random mood entries to enable users to try out the reporting functionality.

All added data has (demo) in the Trigger field to facility removal of data.    

Closes #61 
